### PR TITLE
add create_cohort function

### DIFF
--- a/cloudos/cohorts/cohort.py
+++ b/cloudos/cohorts/cohort.py
@@ -80,14 +80,13 @@ class Cohort(object):
             The specific Cloudos workspace id.
         cohort_name : string
             The name to assign to the new cohort.
-        Cohort_desc : string
+        cohort_desc : string
             The description to assign to the new cohort. (Optional)
 
         Returns
         -------
         Cohort
         """
-
         headers = {"apikey": apikey,
                    "Accept": "application/json, text/plain, */*",
                    "Content-Type": "application/json;charset=UTF-8"}


### PR DESCRIPTION
## Overview and purpose
+ Adds the classmethod `Cohort.create()` to create a new cohort in the cohort browser and instantiate it as a `Cohort` object.
+ Adds the classmethod `Cohort.load()` as a more descriptive alias for the init method of `Cohort` as a way of instantiating a `Cohort` object from an exisiting Cohort Browser cohort.


## How to test
Install from Github. Python >= 3.8 and pip are required.
Clone the repo and install it using pip:

```
git clone https://github.com/lifebit-ai/cloudos-py
cd cloudos-py
git checkout add-create_new_cohort
pip install -r requirements.txt
pip install -e .
```

#### Testing

```python
>>> from cloudos.cohorts import Cohort
>>> cloudos_url = 'http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com'
>>> workspace_id = '5f7c8696d6ea46288645a89f'
>>> apikey = '***'

>>> cohort_id = '61925cf4d46d8c64f215b980'
>>> c = Cohort.load(apikey, cloudos_url, workspace_id, cohort_id=cohort_id)
>>> c.cohort_name
'ilya-testing-001'

>>> c2 = Cohort.create(apikey, cloudos_url, workspace_id, cohort_name="ilya-test-011", cohort_desc="testing from cloudos-py")
>>> c2.cohort_id
'61a7489ccfdf775a1c491fbe'
>>> c2.cohort_name
'ilya-test-011'

>>> c3 = Cohort.create(apikey, cloudos_url, workspace_id, cohort_name="ilya-test-011")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/lifebit-repos/cloudos-py/cloudos/cohorts/cohort.py", line 100, in create
    raise BadRequestException(r)
cloudos.utils.errors.BadRequestException: Server returned status 409. Response:
{"statusCode": 409, "code": "Conflict", "message": "A cohort with name ilya-test-011 already exist for team T - CBDemoTeam", "time": "2021-12-01T10:04:48.842Z"}
```

