### PR TITLE
Add CohortBrowser class

### DIFF
--- a/cloudos/cohorts/__init__.py
+++ b/cloudos/cohorts/__init__.py
@@ -6,4 +6,4 @@ from .cohort import Cohort
 from .cohort_browser import CohortBrowser
 
 
-__all__ = ['cohort']
+__all__ = ['cohort', 'cohort_browser']

--- a/cloudos/cohorts/cohort_browser.py
+++ b/cloudos/cohorts/cohort_browser.py
@@ -2,10 +2,8 @@
 This is the main class for interacting with a cohort browser instance.
 """
 
-import requests
 from dataclasses import dataclass
 from cloudos.cohorts import Cohort
-from cloudos.utils.errors import BadRequestException
 
 
 @dataclass


### PR DESCRIPTION
## Overview and purpose
This PR adds the `CohortBrowser` class which is a class that stores connection information for interacting with a specific cohort instance. In the future, this class will provide methods for interacting with non-cohort specific functionality of the cohort browser.

## How to test
Install from Github. Python >= 3.8 and pip are required.
Clone the repo and install it using pip:

```
git clone https://github.com/lifebit-ai/cloudos-py
cd cloudos-py
git checkout add-cohort_class
pip install -r requirements.txt
pip install -e .
```

#### Testing

```python
>>> from cloudos.cohorts import CohortBrowser, Cohort

>>> cb_workspace = CohortBrowser(apikey='***',
...:                              cloudos_url='http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com',
...:                              workspace_id='5f7c8696d6ea46288645a89f')

>>> my_old_cohort = cb_workspace.load_cohort(cohort_id='61925cf4d46d8c64f215b980')
>>> my_old_cohort.cohort_name
'ilya-testing-001'

>>> new_cohort = cb_workspace.create_cohort(cohort_name="ilya-test-013")
>>> new_cohort.cohort_name
'ilya-test-013'
```