### PR TITLE
added function to list cohorts

### DIFF
--- a/cloudos/cohorts/cohort_browser.py
+++ b/cloudos/cohorts/cohort_browser.py
@@ -100,32 +100,22 @@ class CohortBrowser:
         if size == "all":
             size = 0
             params = {"teamId": self.workspace_id,
-                    "pageNumber": 0,
-                    "pageSize": size}
+                      "pageNumber": 0,
+                      "pageSize": size}
             r = requests.get(f"{self.cloudos_url}/cohort-browser/v2/cohort",
-                            params=params, headers=headers)
+                             params=params, headers=headers)
             if r.status_code >= 400:
                 raise BadRequestException(r)
             r_json = r.json()
             size = r_json['total']
-            # inital request to get total second request to get all
-            params = {"teamId": self.workspace_id,
-                      "pageNumber": 0,
-                      "pageSize": size}
-            r = requests.get(f"{self.cloudos_url}/cohort-browser/v2/cohort",
-                             params=params, headers=headers)
-            if r.status_code >= 400:
-                raise BadRequestException(r)
-            r_json = r.json()
-        else:
-            params = {"teamId": self.workspace_id,
-                      "pageNumber": 0,
-                      "pageSize": size}
-            r = requests.get(f"{self.cloudos_url}/cohort-browser/v2/cohort",
-                             params=params, headers=headers)
-            if r.status_code >= 400:
-                raise BadRequestException(r)
-            r_json = r.json()
+        params = {"teamId": self.workspace_id,
+                  "pageNumber": 0,
+                  "pageSize": size}
+        r = requests.get(f"{self.cloudos_url}/cohort-browser/v2/cohort",
+                            params=params, headers=headers)
+        if r.status_code >= 400:
+            raise BadRequestException(r)
+        r_json = r.json()
         if size > r_json['total']:
             size = r_json['total']
         if size == 10:
@@ -137,9 +127,8 @@ class CohortBrowser:
         values_to_take = ["name", "_id", "description", "numberOfParticipants",
                           "numberOfFilters", "createdAt", "updatedAt"]
         cohort_list = []
-        for i, item in enumerate(r_json['cohorts']):
-            r_json['cohorts'][i]['numberOfFilters'] = len(r_json['cohorts'][i]['phenotypeFilters'])
-            temp_item = {item: r_json['cohorts'][i][item] for item in r_json['cohorts'][i]
-                         if item in values_to_take}
+        for cohort in r_json['cohorts']:
+            temp_item = {k: v for k, v in cohort.items() if k in values_to_take}
+            temp_item['numberOfFilters'] = len(cohort['phenotypeFilters'])
             cohort_list.append(temp_item)
         return cohort_list


### PR DESCRIPTION
## Overview and purpose
Adds one function to list all cohorts on the first page of cohort browser in `cloudos/cohorts/cohort_browser.py`.

+ Adds the `list_cohorts` function gets all the cohorts on the front page of cohort browser (v2). An intiger is used to specify the total cohorts to view on the first page (default 10) and returns a dictionary of the cohorts 
+ Uses the `BadRequestException` class from `cloudos/utils/errors.py` to handle request errors


## How to test
Install from Github. Python >= 3.8 and pip are required.
Clone the repo and install it using pip:

```
git clone https://github.com/lifebit-ai/cloudos-py
cd cloudos-py
git checkout list_cohorts
pip install -r requirements.txt
pip install -e .
```

#### Testing

```python
>>> from cloudos.cohorts import CohortBrowser, Cohort
>>> apikey = '***'
>>> workspace_id = '5f7c8696d6ea46288645a89f'
>>> cloudos_url = 'http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com'
```

Get the default number of cohorts:
```python
>>> cb = CohortBrowser(apikey, cloudos_url, workspace_id)
>>> c = cb.list_cohorts()
Total number of cohorts found: 60. 
Showing 10 by default. Change 'size' parameter to return more.
>>> print(c)
{0: {'name': 'ilya-test-015', 'numberOfParticipants': 44703, 'createdAt': '2021-12-16T13:09:39.852Z', 'updatedAt': '2021-12-17T10:35:24.617Z', 'numberOfFilters': 0}, 1: {'name': 'ilya-test-014', 'description': '', 'numberOfParticipants': 9028, 'createdAt': '2021-12-16T13:03:25.547Z', 'updatedAt': '2021-12-16T13:04:31.500Z', 'numberOfFilters': 0}, 2: {'name': 'Giorgos Test', 'numberOfParticipants': 44703, 'createdAt': '2021-12-10T11:31:50.702Z', 'updatedAt': '2021-12-13T09:16:55.916Z', 'numberOfFilters': 0}, 3: {'name': 'test_1209', 'numberOfParticipants': 44703, 'createdAt': '2021-12-09T13:36:08.444Z', 'updatedAt': '2021-12-09T13:36:31.825Z', 'numberOfFilters': 0}, 4: {'name': 'Giorgos 1', 'numberOfParticipants': 0, 'createdAt': '2021-12-09T10:09:12.928Z', 'updatedAt': '2021-12-09T14:31:59.831Z', 'numberOfFilters': 0}, 5: {'name': 'Manos 2', 'description': '', 'numberOfParticipants': 44702, 'createdAt': '2021-12-09T10:05:32.441Z', 'updatedAt': '2021-12-09T10:05:32.441Z', 'numberOfFilters': 0}, 6: {'name': 'test-shit', 'numberOfParticipants': 4, 'createdAt': '2021-12-03T18:05:11.520Z', 'updatedAt': '2021-12-13T09:18:19.266Z', 'numberOfFilters': 1}, 7: {'name': 'jonny-test-01', 'description': '', 'numberOfParticipants': 44702, 'createdAt': '2021-12-01T16:51:03.659Z', 'updatedAt': '2021-12-01T16:51:03.659Z', 'numberOfFilters': 0}, 8: {'name': 'ilya-test-013', 'numberOfParticipants': 1053, 'createdAt': '2021-12-01T12:35:52.892Z', 'updatedAt': '2021-12-09T16:05:42.017Z', 'numberOfFilters': 1}, 9: {'name': 'cohort 123', 'description': 'test', 'numberOfParticipants': 44702, 'createdAt': '2021-11-29T16:54:30.875Z', 'updatedAt': '2021-11-29T16:54:30.875Z', 'numberOfFilters': 0}}

```

Get a different number of cohorts, e.g. 5:
```python
>>> cb = CohortBrowser(apikey, cloudos_url, workspace_id)
>>> c = cb.list_cohorts(5)
>>> print(c)
{0: {'name': 'ilya-test-015', 'numberOfParticipants': 44703, 'createdAt': '2021-12-16T13:09:39.852Z', 'updatedAt': '2021-12-17T10:35:24.617Z', 'numberOfFilters': 0}, 1: {'name': 'ilya-test-014', 'description': '', 'numberOfParticipants': 9028, 'createdAt': '2021-12-16T13:03:25.547Z', 'updatedAt': '2021-12-16T13:04:31.500Z', 'numberOfFilters': 0}, 2: {'name': 'Giorgos Test', 'numberOfParticipants': 44703, 'createdAt': '2021-12-10T11:31:50.702Z', 'updatedAt': '2021-12-13T09:16:55.916Z', 'numberOfFilters': 0}, 3: {'name': 'test_1209', 'numberOfParticipants': 44703, 'createdAt': '2021-12-09T13:36:08.444Z', 'updatedAt': '2021-12-09T13:36:31.825Z', 'numberOfFilters': 0}, 4: {'name': 'Giorgos 1', 'numberOfParticipants': 0, 'createdAt': '2021-12-09T10:09:12.928Z', 'updatedAt': '2021-12-09T14:31:59.831Z', 'numberOfFilters': 0}}
```