### PR TITLE
Replaces mentions of AMI to instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Options:
                                not.
   --batch                      Whether to make use the batch executor instead
                                of the default ignite.
-  --instance-type TEXT         The type of AMI to use. Default=c5.xlarge.
+  --instance-type TEXT         The type of AWS EC2 instance to use. Default=c5.xlarge.
   --instance-disk INTEGER      The amount of disk storage to configure.
                                Default=500.
   --spot                       Whether to make a spot instance.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Options:
                                not.
   --batch                      Whether to make use the batch executor instead
                                of the default ignite.
-  --instance-type TEXT         The type of AWS EC2 instance to use. Default=c5.xlarge.
+  --instance-type TEXT         Name of the instance type to be used for the job master node. Default=c5.xlarge.
   --instance-disk INTEGER      The amount of disk storage to configure.
                                Default=500.
   --spot                       Whether to make a spot instance.

--- a/cloudos/__main__.py
+++ b/cloudos/__main__.py
@@ -86,7 +86,7 @@ def cromwell():
               help='Whether to make use the batch executor instead of the default ignite.',
               is_flag=True)
 @click.option('--instance-type',
-              help='The type of AWS EC2 instance to use. Default=c5.xlarge.',
+              help='Name of the instance type to be used for the job master node. Default=c5.xlarge.',
               default='c5.xlarge')
 @click.option('--instance-disk',
               help='The amount of disk storage to configure. Default=500.',

--- a/cloudos/__main__.py
+++ b/cloudos/__main__.py
@@ -86,7 +86,7 @@ def cromwell():
               help='Whether to make use the batch executor instead of the default ignite.',
               is_flag=True)
 @click.option('--instance-type',
-              help='The type of AMI to use. Default=c5.xlarge.',
+              help='The type of AWS EC2 instance to use. Default=c5.xlarge.',
               default='c5.xlarge')
 @click.option('--instance-disk',
               help='The amount of disk storage to configure. Default=500.',

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -198,7 +198,7 @@ class Job(Cloudos):
         nextflow_profile: string
             A comma separated string with the profiles to be used.
         instance_type : string
-            Name of the instance type to choose, for example for AWS EC2 c5.xlarge.
+            Name of the instance type to be used for the job master node, for example for AWS EC2 c5.xlarge.
         instance_disk : int
             The disk space of the instance, in GB.
         spot : bool
@@ -374,7 +374,7 @@ class Job(Cloudos):
         nextflow_profile: string
             A comma separated string with the profiles to be used.
         instance_type : string
-            Name of the instance type to choose, for example for AWS EC2 c5.xlarge.
+            Name of the instance type to be used for the job master node, for example for AWS EC2 c5.xlarge.
         instance_disk : int
             The disk space of the instance, in GB.
         spot : bool

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -198,7 +198,7 @@ class Job(Cloudos):
         nextflow_profile: string
             A comma separated string with the profiles to be used.
         instance_type : string
-            Name of the AMI to choose.
+            Name of the instance type to choose, for example for AWS EC2 c5.xlarge.
         instance_disk : int
             The disk space of the instance, in GB.
         spot : bool
@@ -374,7 +374,7 @@ class Job(Cloudos):
         nextflow_profile: string
             A comma separated string with the profiles to be used.
         instance_type : string
-            Type of the AMI to choose.
+            Name of the instance type to choose, for example for AWS EC2 c5.xlarge.
         instance_disk : int
             The disk space of the instance, in GB.
         spot : bool


### PR DESCRIPTION
## Overview

This PR rephrases to use the correct AWS resource naming for the machine selection (instance type for AWS, vm for Google Cloud Platform)

The user chooses the EC2 instance and not the AMI, we will have to correct the phrasing in the docs and docstrings.

https://github.com/lifebit-ai/cloudos-cli/search?q=ami

<img width="1254" alt="Screenshot 2022-07-24 at 15 08 36" src="https://user-images.githubusercontent.com/38183826/180650878-e6634060-20d2-4160-aeed-dfb6d11a33d8.png">

## Changes

- Replaces occurrences of the term `AMI` with `instance type`
- Clarification that this will be the instance type used for the master node.