### PR TITLE
Feat: adds ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,6 @@ jobs:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
-        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot --wait-completion
+        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
+        JOB_ID=$(grep -q -e "Your assigned job id is:" | rev | cut -f1 -d " " | rev)
+        cloudos job status --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run tests
       run: |
         pytest
-  cloudos_cli_tests:
+  job_list:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,3 +55,25 @@ jobs:
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
         cloudos job list --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID
+  job_run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install dependencies
+      run: |
+        pip install -e .
+    - name: Run tests
+      env:
+        CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
+        CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+      run: |
+        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot --wait-completion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: cloudos-cli CI tests
+name: CI tests
 
 on:
   pull_request:
@@ -76,7 +76,7 @@ jobs:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
-        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
+        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --job_name "cloudos-cli-CI-test" --instance-type "c5.large" --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID
   workflow_list:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         PR_NUMBER: ${{ github.event.number }}
         INSTANCE_TYPE: "c5.large"
       run: |
-          JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""${COMMIT_HASH:0:6}""|PR-NUMBER:""$PR_NUMBER"
+        JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""${COMMIT_HASH:0:6}""|PR-NUMBER:""$PR_NUMBER"
         cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG --job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
         cloudos job list --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID
-  job_run:
+  job_run_and_status:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,3 +79,25 @@ jobs:
         cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID
+  workflow_list:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install dependencies
+      run: |
+        pip install -e .
+    - name: Run tests
+      env:
+        CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
+        CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+      run: |
+        cloudos workflow list --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,4 @@ jobs:
       run: |
         cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -q -e "Your assigned job id is:" | rev | cut -f1 -d " " | rev)
-        cloudos job status --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --job-id $JOB_ID
+        cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,5 @@ jobs:
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
         cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
-        JOB_ID=$(grep -q -e "Your assigned job id is:" | rev | cut -f1 -d " " | rev)
+        JOB_ID=$(grep -q -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
         CLOUDOS_URL: "https://staging.lifebit.ai"
-        PROJECT_NAME: "cloudos-cli-tests"
+        PROJECT_NAME: "ci-testing"
         WORKFLOW: "rnatoy"
         JOB_CONFIG: "cloudos/examples/rnatoy.config"
         JOB_NAME_BASE: "cloudos-cli-CI-test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,12 @@ jobs:
         PROJECT_NAME: "cloudos-cli-tests"
         WORKFLOW: "rnatoy"
         JOB_CONFIG: "cloudos/examples/rnatoy.config"
-        JOB_NAME: "cloudos-cli-CI-test|GitHubCommit:" + ${{ github.event.pull_request.head.sha }} + "|PR-NUMBER:" + ${{ github.event.number }}
+        JOB_NAME_BASE: "cloudos-cli-CI-test"
+        COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.number }}
         INSTANCE_TYPE: "c5.xlarge"
       run: |
+        JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""$COMMIT_HASH""|PR-NUMBER:""$PR_NUMBER"
         cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG--job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,5 @@ jobs:
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
         cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
-        cat out.txt
-        JOB_ID=`grep -q -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev`
-        echo $JOB_ID
+        JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,25 @@ jobs:
     - name: Run tests
       run: |
         pytest
+  Pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install dependencies
+      run: |
+        pip install -e .
+    - name: Run tests
+      env:
+        CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
+        CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+      run: |
+        cloudos job list --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         JOB_NAME_BASE: "cloudos-cli-CI-test"
         COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         PR_NUMBER: ${{ github.event.number }}
-        INSTANCE_TYPE: "c5.xlarge"
+        INSTANCE_TYPE: "c5.large"
       run: |
           JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""${COMMIT_HASH:0:6}""|PR-NUMBER:""$PR_NUMBER"
         cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG --job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
-        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --job_name "cloudos-cli-CI-test" --instance-type "c5.large" --spot 2>&1 | tee out.txt
+        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --job-name "cloudos-cli-CI-test" --instance-type "c5.large" --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID
   workflow_list:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         PROJECT_NAME: "cloudos-cli-tests"
         WORKFLOW: "rnatoy"
         JOB_CONFIG: "cloudos/examples/rnatoy.config"
-        JOB_NAME: "cloudos-cli-CI-test|GitHubCommit:"${{ github.event.pull_request.head.sha  }}"|PR-NUMBER:"${{ github.event.number  }}
+        JOB_NAME: "cloudos-cli-CI-test|GitHubCommit:" + ${{ github.event.pull_request.head.sha  }} + "|PR-NUMBER:" + ${{ github.event.number  }}
         INSTANCE_TYPE: "c5.xlarge"
       run: |
         cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG--job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
         CLOUDOS_URL: "https://staging.lifebit.ai"
-        PROJECT_NAME: "ci-testing"
-        WORKFLOW: "rnatoy"
+        PROJECT_NAME: "cloudos-cli-tests"
+        WORKFLOW: "GH-rnatoy"
         JOB_CONFIG: "cloudos/examples/rnatoy.config"
         JOB_NAME_BASE: "cloudos-cli-CI-test"
         COMMIT_HASH: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         PR_NUMBER: ${{ github.event.number }}
         INSTANCE_TYPE: "c5.xlarge"
       run: |
-        JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""$COMMIT_HASH""|PR-NUMBER:""$PR_NUMBER"
+          JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""${COMMIT_HASH:0:6}""|PR-NUMBER:""$PR_NUMBER"
         cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG --job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run tests
       run: |
         pytest
-  Pytest:
+  cloudos_cli_tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,7 @@ jobs:
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
       run: |
         cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --instance-type "c5.large" --spot 2>&1 | tee out.txt
-        JOB_ID=$(grep -q -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
+        cat out.txt
+        JOB_ID=`grep -q -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev`
+        echo $JOB_ID
         cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,9 @@ jobs:
       env:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+        CLOUDOS_URL: "https://staging.lifebit.ai"
       run: |
-        cloudos job list --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID
+        cloudos job list --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID
   job_run_and_status:
     runs-on: ubuntu-latest
     strategy:
@@ -75,10 +76,16 @@ jobs:
       env:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+        CLOUDOS_URL: "https://staging.lifebit.ai"
+        PROJECT_NAME: "cloudos-cli-tests"
+        WORKFLOW: "rnatoy"
+        JOB_CONFIG: "cloudos/examples/rnatoy.config"
+        JOB_NAME: "cloudos-cli-CI-test|GitHubCommit:"${{ github.event.pull_request.head.sha  }}"|PR-NUMBER:"${{ github.event.number  }}
+        INSTANCE_TYPE: "c5.xlarge"
       run: |
-        cloudos job run --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "API jobs" --workflow-name rnatoy --job-config "cloudos/examples/rnatoy.config" --job-name "cloudos-cli-CI-test" --instance-type "c5.large" --spot 2>&1 | tee out.txt
+        cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG--job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
-        cloudos job status --apikey $CLOUDOS_TOKEN --job-id $JOB_ID
+        cloudos job status --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --job-id $JOB_ID
   workflow_list:
     runs-on: ubuntu-latest
     strategy:
@@ -99,5 +106,6 @@ jobs:
       env:
         CLOUDOS_TOKEN: ${{ secrets.CLOUDOS_TOKEN }}
         CLOUDOS_WORKSPACE_ID: ${{ secrets.CLOUDOS_WORKSPACE_ID }}
+        CLOUDOS_URL: "https://staging.lifebit.ai"
       run: |
-        cloudos workflow list --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID
+        cloudos workflow list --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: cloudos-cli CI tests
+
+on:
+  pull_request:
+    types: [review_requested, ready_for_review]
+    branches:
+      - main
+      - dev
+    paths-ignore:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  Pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install dependencies
+      run: |
+        pip install -e '.[test]'
+    - name: Run tests
+      run: |
+        pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         PROJECT_NAME: "cloudos-cli-tests"
         WORKFLOW: "rnatoy"
         JOB_CONFIG: "cloudos/examples/rnatoy.config"
-        JOB_NAME: "cloudos-cli-CI-test|GitHubCommit:" + ${{ github.event.pull_request.head.sha  }} + "|PR-NUMBER:" + ${{ github.event.number  }}
+        JOB_NAME: "cloudos-cli-CI-test|GitHubCommit:" + ${{ github.event.pull_request.head.sha }} + "|PR-NUMBER:" + ${{ github.event.number }}
         INSTANCE_TYPE: "c5.xlarge"
       run: |
         cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG--job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         INSTANCE_TYPE: "c5.xlarge"
       run: |
         JOB_NAME="$JOB_NAME_BASE""|GitHubCommit:""$COMMIT_HASH""|PR-NUMBER:""$PR_NUMBER"
-        cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG--job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt
+        cloudos job run --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --workspace-id $CLOUDOS_WORKSPACE_ID --project-name "$PROJECT_NAME" --workflow-name "$WORKFLOW" --job-config $JOB_CONFIG --job-name "$JOB_NAME" --instance-type $INSTANCE_TYPE --spot 2>&1 | tee out.txt
         JOB_ID=$(grep -e "Your assigned job id is:" out.txt | rev | cut -f1 -d " " | rev)
         cloudos job status --cloudos-url $CLOUDOS_URL --apikey $CLOUDOS_TOKEN --job-id $JOB_ID
   workflow_list:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ]},
     install_requires=["click", "pandas", "requests"],
     extras_require={
-        "test": ["pytest", "mock"]
+        "test": ["pytest", "mock", "responses"]
     },
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,9 @@ setuptools.setup(
     entry_points={"console_scripts": [
         "cloudos=cloudos.__main__:run_cloudos_cli"
     ]},
+    install_requires=["click", "pandas", "requests"],
+    extras_require={
+        "test": ["pytest"]
+    },
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ]},
     install_requires=["click", "pandas", "requests"],
     extras_require={
-        "test": ["pytest"]
+        "test": ["pytest", "mock"]
     },
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ]},
     install_requires=["click", "pandas", "requests"],
     extras_require={
-        "test": ["pytest", "mock", "responses"]
+        "test": ["pytest", "mock", "responses", "requests_mock"]
     },
     include_package_data=True
 )


### PR DESCRIPTION
## Jira ticket

https://lifebit.atlassian.net/browse/CLOUDOSCLI-134

## Overview

This PR adds a CI tests.

Tests added are the following:
- Pytest: unit tests testing all package functions.
- CI tests to all `cli` available methods:
    * `cloudos job list`
    * `cloudos job run` & `cloudos job status`
    * `cloudos workflow list`
> Note: all the `cromwell` related methods are still pending on an open CloudOS implementing `cromwell` server.

## Changes
- Adds `.github/workflows/ci.yml`
- Minor modifications to `setup.py` to automatically manage dependencies during installation.

## Tests
See GitHub actions tests.

![Screenshot from 2023-03-22 19-06-08](https://user-images.githubusercontent.com/45285897/226999560-335df8e1-c4de-4791-80b5-3d72c488983a.png)
![Screenshot from 2023-03-22 19-15-04](https://user-images.githubusercontent.com/45285897/226999577-a75d06fd-7c2f-4047-807e-0dd533cd3296.png)


> NOTE: the PR is not doing any modification on actual `cloudos-cli` package code, therefore no new release or version bump is needed. CI tests will be absorbed by `main` on the next release event.