### PR TITLE
Feat: adds commitizen

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,52 @@
+[tool.commitizen]
+name = "cz_customize"
+version = "2.1.0"
+tag_format = "v$major.$minor.$patch"
+
+[tool.commitizen.customize]
+message_template = "{{change_type}}{% if scope %}({{scope}}){% endif %}: {{message}}"
+example = "feat: this feature enable customize through config file"
+schema = "<type>(<scope>): <subject>"
+schema_pattern = "(break|feat|fix|docs|style|refactor|perf|test|build|ci|revert):(\\s.*)"
+bump_pattern = "^(BREAKING[\\-\\ ]CHANGE|break|feat|fix|refactor|perf)(\\(.+\\))?(!)?"
+bump_map = { "break" = "MAJOR", "feat" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH" }
+change_type_order = ["BREAKING CHANGE", "break", "feat", "fix", "refactor", "perf"]
+info_path = "cz_customize_info.txt"
+info = """
+This is customized info
+"""
+# add here all types that you want to be displayed in the CHANGELOG
+commit_parser = "^(?P<change_type>break|feat|fix|docs|style|refactor|perf|test|config|build|ci)(?:\\((?P<scope>[^()\\r\\n]*)\\)|\\()?(?P<breaking>!)?:\\s(?P<message>.*)?"
+changelog_pattern = "^(break|feat|fix|docs)?(!)?"
+# the title in the section in chengelog is defined here
+change_type_map = {"break" = "Breaking Change","feat" = "Feature","fix" = "Bugfix / Hotfix / Patch","docs" = "Documentation","style" = "Style","refactor" = "Refactor","perf" = "Performance","test" = "Test","config" = "Configuration","build" = "Build","ci" = "CI" }
+
+[[tool.commitizen.customize.questions]]
+type = "list"
+name = "change_type"
+choices = [
+    {value = "break", name = "break: A backwards-incompatible change. Correlates with MAJOR in SemVer"},
+    {value = "feat", name = "feat: A new feature. Correlates with MINOR in SemVer"},
+    {value = "fix", name = "fix: A bug fix. Correlates with PATCH in SemVer"},
+    {value = "docs", name = "docs: Documentation only changes"},
+    {value = "style", name = "style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"},
+    {value = "refactor", name = "refactor: A code change that neither fixes a bug nor adds a feature"},
+    {value = "perf", name = "perf: A code change that improves performance"},
+    {value = "test", name = "test: Adding missing or correcting existing tests"},
+    {value = "config", name = "config: Changes that affect the configuration-related files (for example in the 'conf' folder)"},
+    {value = "build", name = "build: Changes that affect the build system or external dependencies (example scopes: pip, docker, npm)"},
+    {value = "ci", name = "ci: Changes to our CI configuration files and scripts (example scopes: GitLabCI)"},
+]
+
+# first message
+message = "Select the type of change you are committing\n"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "scope"
+message = "What is the scope of this change? (class or file name): (press [enter] to skip)\n"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "message"
+message = "Write a short summary of the code changes: (lower case and no period)\n"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## lifebit-ai/cloudos-cli: changelog
 
+## Unreleased
+
+### Documentation
+
+- add commitizen support
+
 ### 2.1.0 - 2023-03-30
 - Feature: `cloudos job list` has the new parameter `--last-n-jobs n`, if used, the last
 `n` jobs from the user will be collected. Default is last 30, which was the previous behaviour.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # cloudos
 
-__Date:__ 2023-03-30\
-__Version:__ 2.1.0
-
-
 Python package for interacting with CloudOS
 
 ## Requirements
@@ -25,7 +21,7 @@ and the `environment.yml` files provided.
 To run the existing docker image at `quay.io`:
 
 ```bash
-docker run --rm -it quay.io/lifebitaiorg/cloudos-cli:v2.1.0
+docker run --rm -it quay.io/lifebitaiorg/cloudos-cli:latest
 ```
 
 ### From Github
@@ -76,16 +72,6 @@ own subcommands with its own `--help`:
 cloudos job run --help
 ```
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
-Usage: cloudos job run [OPTIONS]
-
-  Submit a job to CloudOS.
-
 Options:
   -k, --apikey TEXT           Your CloudOS API key  [required]
   -c, --cloudos-url TEXT      The CloudOS url you are trying to access to.
@@ -218,12 +204,6 @@ cloudos job run \
 If everything went well, you should see something like:
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
 Executing run...
 	Job successfully launched to CloudOS, please check the following link: https://cloudos.lifebit.ai/app/jobs/62c83a1191fe06013b7ef355
 	Your assigned job id is: 62c83a1191fe06013b7ef355
@@ -261,12 +241,6 @@ If the job takes less than `--wait-time` (3600 seconds by default), the
 previous command should have an output similar to:
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
 Executing run...
 	Job successfully launched to CloudOS, please check the following link: https://cloudos.lifebit.ai/app/jobs/62c83a6191fe06013b7ef363
 	Your assigned job id is: 62c83a6191fe06013b7ef363
@@ -290,12 +264,6 @@ cloudos job status \
 The expected output should be something similar to:
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
 Executing status...
 	Your current job status is: completed
 
@@ -326,12 +294,6 @@ cloudos job list \
 The expected output is something similar to:
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
 Executing list...
 	Job list collected with a total of 30 jobs.
 	Job list saved to joblist.csv
@@ -350,12 +312,6 @@ cloudos job list \
     --output-format json
 ```
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
 Executing list...
 	Job list collected with a total of 276 jobs.
 	Job list saved to joblist.json
@@ -383,12 +339,6 @@ cloudos workflow list \
 The expected output is something similar to:
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS workflow functionality: list workflows in CloudOS.
-
 Executing list...
 	Workflow list collected with a total of 609 workflows.
 	Workflow list saved to workflow_list.csv
@@ -405,12 +355,6 @@ cloudos workflow list \
 ```
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS workflow functionality: list workflows in CloudOS.
-
 Executing list...
 	Workflow list collected with a total of 609 workflows.
 	Workflow list saved to workflow_list.json
@@ -432,12 +376,6 @@ cloudos cromwell status \
 ```
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-Cromwell server functionality: check status, start and stop.
-
 Executing status...
 	Current Cromwell server status is: Stopped
 ```
@@ -451,12 +389,6 @@ cloudos cromwell start \
 ```
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-Cromwell server functionality: check status, start and stop.
-
 Starting Cromwell server...
 	Current Cromwell server status is: Initializing
 
@@ -472,12 +404,6 @@ cloudos cromwell stop \
 ```
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-Cromwell server functionality: check status, start and stop.
-
 Stopping Cromwell server...
 	Current Cromwell server status is: Stopped
 ```
@@ -538,12 +464,6 @@ cloudos job run \
 ```
 
 ```console
-CloudOS python package: a package for interacting with CloudOS.
-
-Version: 2.1.0
-
-CloudOS job functionality: run and check jobs in CloudOS.
-
 Executing run...
     WDL workflow detected
 


### PR DESCRIPTION
## Jira ticket

https://lifebit.atlassian.net/browse/DEL-13067

## Overview

The present PR adds commitizen to the repository (https://github.com/lifebit-ai/cloudos-cli/issues/92, https://github.com/lifebit-ai/cloudos-cli/issues/94 & https://github.com/lifebit-ai/cloudos-cli/issues/91).

With commitizen, all changes will be automatically added to the `CHANGELOG.md` and version bump will only occur after version-changing commits of type `break`, `feat` or `fix`. See https://lifebit.atlassian.net/wiki/spaces/DEL/pages/198672421/Commitizen+usage+compliance and the official documentation https://commitizen-tools.github.io/commitizen/ for more details.

## Changes

- Removes all version references from README.md
- New docker container version: quay.io/lifebitaiorg/cloudos-cli:latest
- Adds `cz.toml` file with commitizen configuration
- Automatic update of `CHANGELOG.md` to test commitizen:
    * Install commitizen in your system: `pip install commitizen`
    * Copy `cz.toml`  from https://lifebit.atlassian.net/wiki/spaces/DEL/pages/219709517/.cz.toml
    * Update `cz.toml` file to have the current version (v2.1.0)
    * Add a git tag: `git tag -a v2.1.0 -m "v2.1.0"`
    * `git add .`
    * `cz commit` (see screenshot for the output)
    * Update the changelog automatically: `cz changelog --incremental` . With the incremental flag, the previous changelog is not modified and only the new (unreleased) changes are added. Please, note that a `doc` commit will not trigger a version bump, so the version will stay the same and the new changes appear as "Unreleased" in the changelog.
    * Add and commit the new changelog: `git add . && git commit -m "changelog"`

![Screenshot from 2023-04-03 17-13-20](https://user-images.githubusercontent.com/45285897/229552462-1828b48b-63bd-42c1-90f8-d78e2ca3281c.png)


## Tests

Not necessary for documentation related PRs.