### PR TITLE
Remove numpy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The package requires Python >= 3.7 and the following python packages:
 ```
 click>=8.0.1
 pandas>=1.3.4
-numpy==1.26.4
 requests>=2.26.0
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,3 @@ dependencies:
     - requests
     - click
     - pandas
-    - numpy==1.26.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ click>=8.0.1
 requests>=2.26.0
 requests-mock>=1.9.3
 pandas>=1.3.4
-numpy==1.26.4
 pytest>=6.2.5
 responses>=0.21.0
 mock>=3.0.5

--- a/tests/test_clos/test_process_job_list.py
+++ b/tests/test_clos/test_process_job_list.py
@@ -3,7 +3,6 @@ import pytest
 import requests_mock
 import requests
 import pandas as pd
-import numpy as np
 from cloudos.clos import Cloudos
 
 input_json = "tests/test_data/process_job_list_initial_json.json"
@@ -52,7 +51,7 @@ def test_process_job_list_df_values_equal(mocked_requests_get,):
                           'workflow.updatedAt', 'workflow.workflowType',
                           'project._id', 'project.name',
                           'project.createdAt', 'project.updatedAt']
-    assert np.all(df[columns_to_compare] == output_df[columns_to_compare])
+    pd.testing.assert_frame_equal(df[columns_to_compare], output_df[columns_to_compare])
 
 
 def test_process_job_list_full_has_correct_columns(mocked_requests_get):


### PR DESCRIPTION
As `numpy` dependency have [import issues](https://numpy.org/devdocs/user/troubleshooting-importerror.html) in certain environments and also only used in one place in the codebase, it is safe to be replaced with alternative one. 

