### PR TITLE
Fix: data items

### DIFF
--- a/cloudos_cli/__main__.py
+++ b/cloudos_cli/__main__.py
@@ -951,17 +951,16 @@ def job_details(ctx,
             'arrayFileColumn': 'columnName',
             'globPattern': 'globPattern',
             'lustreFileSystem': 'fileSystem',
+            'dataItem': 'dataItem'
         }
         # there are different types of parameters, arrayFileColumn, globPattern, lustreFileSystem
         # get first the type of parameter, then the value based on the parameter kind
         concats = []
         for param in j_details_h["parameters"]:
+            value = param[param_kind_map[param['parameterKind']]]
             if param['parameterKind'] == 'dataItem':
-                # For dataItem, we need to use specific nested keys
-                concats.append(f"{param['prefix']}{param['name']}={param['dataItem']['item']['name']}")
-            else:
-                # For other parameter kinds, we use the appropriate key from param_kind_map
-                concats.append(f"{param['prefix']}{param['name']}={param[param_kind_map[param['parameterKind']]]}")
+                value = value['item']['name']
+            concats.append(f"{param['prefix']}{param['name']}={value}")
         concat_string = '\n'.join(concats)
         # If the user requested to save the parameters in a config file
         if parameters:
@@ -970,7 +969,10 @@ def job_details(ctx,
             with open(config_filename, 'w') as config_file:
                 config_file.write("params {\n")
                 for param in j_details_h["parameters"]:
-                    config_file.write(f"\t{param['name']} = {param['textValue']}\n")
+                    value = param[param_kind_map[param['parameterKind']]]
+                    if param['parameterKind'] == 'dataItem':
+                        value = value['item']['name']
+                    config_file.write(f"\t{param['name']} = {value}\n")
                 config_file.write("}\n")
             print(f"\tJob parameters have been saved to '{config_filename}'")
     else:


### PR DESCRIPTION
# Fix `dataItem` mapping

## Tests

### `dataItem` is present as a parameter (also globPattern, textValue)

https://dev.sdlc.lifebit.ai/app/advanced-analytics/analyses/685bef9d2ec92be21cf31f27

<img width="1359" alt="image" src="https://github.com/user-attachments/assets/eea4a01b-4b0e-4157-8b81-b0ef3a47255c" />
<img width="661" alt="image" src="https://github.com/user-attachments/assets/2f280648-a2d5-446f-bd30-1614153b1d3c" />

```console
Executing details...
                                  Job Details                                  
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Field                    ┃ Value                                            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Job Status               │ completed                                        │
│ Parameters               │ --dataLocation=input_files                       │
│                          │ --glob_param=*.csv                               │
│                          │ --file_param=nxf.Ma_file_1.txt                   │
│ Revision                 │ 4f97444a7e23a89d1ebec5c760572e3c4a4ff108         │
│ Nextflow Version         │ 22.10.8                                          │
│ Execution Platform       │ Batch AWS                                        │
│ Profile                  │ None                                             │
│ Master Instance          │ c5.xlarge                                        │
│ Storage                  │ 500 GB                                           │
│ Job Queue ID             │ nextflow-job-queue-660feb3683c02e208316d581-edd4 │
│ Job Queue Name           │ LATEST                                           │
│ Accelerated File Staging │ False                                            │
│ Task Resources           │ 1 CPUs, 4 GB RAM                                 │
└──────────────────────────┴──────────────────────────────────────────────────┘
```

