### PR TITLE
patch: add workspace_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1741,7 +1741,7 @@ j_id = j.send_job(job_config)
 To check the status:
 
 ```python
-j_status = j.get_job_status(j_id)
+j_status = j.get_job_status(j_id, workspace_id)
 j_status_h = json.loads(j_status.content)["status"]
 print(j_status_h)
 ```
@@ -1816,7 +1816,7 @@ print(c_status_h)
 j = jb.Job(cloudos_url, apikey, None, workspace_id, project_name, workflow_name, True, mainfile,
            importsfile)
 j_id = j.send_job(job_config, workflow_type='wdl', cromwell_id=json.loads(c_status.content)["_id"])
-j_status = j.get_job_status(j_id)
+j_status = j.get_job_status(j_id, workspace_id)
 j_status_h = json.loads(j_status.content)["status"]
 print(j_status_h)
 

--- a/cloudos_cli/__main__.py
+++ b/cloudos_cli/__main__.py
@@ -780,6 +780,7 @@ def run(ctx,
         print('\tPlease, wait until job completion (max wait time of ' +
               f'{wait_time} seconds).\n')
         j_status = j.wait_job_completion(job_id=j_id,
+                                         workspace_id=workspace_id,
                                          wait_time=wait_time,
                                          request_interval=request_interval,
                                          verbose=verbose,
@@ -793,7 +794,7 @@ def run(ctx,
             print(f'\nJob status for job "{j_name}" (ID: {j_id}): {j_final_s}')
             sys.exit(1)
     else:
-        j_status = j.get_job_status(j_id, verify_ssl)
+        j_status = j.get_job_status(j_id, workspace_id, verify_ssl)
         j_status_h = json.loads(j_status.content)["status"]
         print(f'\tYour current job status is: {j_status_h}')
         print('\tTo further check your job status you can either go to ' +
@@ -812,6 +813,9 @@ def run(ctx,
               '--cloudos-url',
               help=(f'The CloudOS url you are trying to access to. Default={CLOUDOS_URL}.'),
               default=CLOUDOS_URL,
+              required=True)
+@click.option('--workspace-id',
+              help='The specific CloudOS workspace id.',
               required=True)
 @click.option('--job-id',
               help='The job id in CloudOS to search for.',
@@ -841,7 +845,7 @@ def job_status(ctx,
     # Create a dictionary with required and non-required params
     required_dict = {
         'apikey': True,
-        'workspace_id': False,
+        'workspace_id': True,
         'workflow_name': False,
         'project_name': False,
         'session_id': False,
@@ -862,6 +866,7 @@ def job_status(ctx,
     )
     apikey = user_options['apikey']
     cloudos_url = user_options['cloudos_url']
+    workspace_id = user_options['workspace_id']
 
     print('Executing status...')
     verify_ssl = ssl_selector(disable_ssl_verification, ssl_cert)
@@ -873,7 +878,7 @@ def job_status(ctx,
         print('\t' + str(cl) + '\n')
         print(f'\tSearching for job id: {job_id}')
     try:
-        j_status = cl.get_job_status(job_id, verify_ssl)
+        j_status = cl.get_job_status(job_id, workspace_id, verify_ssl)
         j_status_h = json.loads(j_status.content)["status"]
         print(f'\tYour current job status is: {j_status_h}\n')
         j_url = f'{cloudos_url}/app/advanced-analytics/analyses/{job_id}'
@@ -1149,6 +1154,9 @@ def job_results(ctx,
               help=(f'The CloudOS url you are trying to access to. Default={CLOUDOS_URL}.'),
               default=CLOUDOS_URL,
               required=True)
+@click.option('--workspace-id',
+              help='The specific CloudOS workspace id.',
+              required=True)
 @click.option('--job-id',
               help='The job id in CloudOS to search for.',
               required=True)
@@ -1193,7 +1201,7 @@ def job_details(ctx,
     # Create a dictionary with required and non-required params
     required_dict = {
         'apikey': True,
-        'workspace_id': False,
+        'workspace_id': True,
         'workflow_name': False,
         'project_name': False,
         'session_id': False,
@@ -1214,6 +1222,7 @@ def job_details(ctx,
     )
     apikey = user_options['apikey']
     cloudos_url = user_options['cloudos_url']
+    workspace_id = user_options['workspace_id']
 
     if ctx.get_parameter_source('output_basename') == click.core.ParameterSource.DEFAULT:
         output_basename = f"{job_id}_details"
@@ -1230,7 +1239,7 @@ def job_details(ctx,
 
     # check if the API gives a 403 error/forbidden error
     try:
-        j_details = cl.get_job_status(job_id, verify_ssl)
+        j_details = cl.get_job_status(job_id, workspace_id, verify_ssl)
     except BadRequestException as e:
         if '403' in str(e) or 'Forbidden' in str(e):
             raise ValueError("API can only show job details of your own jobs, cannot see other user's job details.")
@@ -1518,7 +1527,7 @@ def abort_jobs(ctx,
 
     for job in jobs:
         try:
-            j_status = cl.get_job_status(job, verify_ssl)
+            j_status = cl.get_job_status(job, workspace_id, verify_ssl)
         except Exception as e:
             click.secho(f"Failed to get status for job {job}, please make sure it exists in the workspace: {e}", fg='yellow', bold=True)
             continue
@@ -2823,6 +2832,7 @@ def run_bash_job(ctx,
         print('\tPlease, wait until job completion (max wait time of ' +
               f'{wait_time} seconds).\n')
         j_status = j.wait_job_completion(job_id=j_id,
+                                         workspace_id=workspace_id,
                                          wait_time=wait_time,
                                          request_interval=request_interval,
                                          verbose=False,
@@ -2836,7 +2846,7 @@ def run_bash_job(ctx,
             print(f'\nJob status for job "{j_name}" (ID: {j_id}): {j_final_s}')
             sys.exit(1)
     else:
-        j_status = j.get_job_status(j_id, verify_ssl)
+        j_status = j.get_job_status(j_id, workspace_id, verify_ssl)
         j_status_h = json.loads(j_status.content)["status"]
         print(f'\tYour current job status is: {j_status_h}')
         print('\tTo further check your job status you can either go to ' +
@@ -3191,6 +3201,7 @@ def run_bash_array_job(ctx,
         print('\tPlease, wait until job completion (max wait time of ' +
               f'{wait_time} seconds).\n')
         j_status = j.wait_job_completion(job_id=j_id,
+                                         workspace_id=workspace_id,
                                          wait_time=wait_time,
                                          request_interval=request_interval,
                                          verbose=False,
@@ -3204,7 +3215,7 @@ def run_bash_array_job(ctx,
             print(f'\nJob status for job "{j_name}" (ID: {j_id}): {j_final_s}')
             sys.exit(1)
     else:
-        j_status = j.get_job_status(j_id, verify_ssl)
+        j_status = j.get_job_status(j_id, workspace_id, verify_ssl)
         j_status_h = json.loads(j_status.content)["status"]
         print(f'\tYour current job status is: {j_status_h}')
         print('\tTo further check your job status you can either go to ' +

--- a/cloudos_cli/clos.py
+++ b/cloudos_cli/clos.py
@@ -37,13 +37,15 @@ class Cloudos:
     apikey: str
     cromwell_token: str
 
-    def get_job_status(self, j_id, verify=True):
+    def get_job_status(self, j_id, workspace_id, verify=True):
         """Get job status from CloudOS.
 
         Parameters
         ----------
         j_id : string
             The CloudOS job id of the job just launched.
+        workspace_id : string
+            The CloudOS workspace id from to check the job status.
         verify: [bool|string]
             Whether to use SSL verification or not. Alternatively, if
             a string is passed, it will be interpreted as the path to
@@ -60,21 +62,23 @@ class Cloudos:
             "Content-type": "application/json",
             "apikey": apikey
         }
-        r = retry_requests_get("{}/api/v1/jobs/{}".format(cloudos_url,
-                                                          j_id),
+        r = retry_requests_get("{}/api/v1/jobs/{}?teamID={}".format(cloudos_url,
+                                                          j_id, workspace_id),
                                headers=headers, verify=verify)
         if r.status_code >= 400:
             raise BadRequestException(r)
         return r
 
-    def wait_job_completion(self, job_id, wait_time=3600, request_interval=30, verbose=False,
+    def wait_job_completion(self, job_id, workspace_id, wait_time=3600, request_interval=30, verbose=False,
                             verify=True):
         """Checks job status from CloudOS and wait for its complation.
 
         Parameters
         ----------
-        j_id : string
+        job_id : string
             The CloudOS job id of the job just launched.
+        workspace_id : string
+            The CloudOS workspace id from to check the job status.
         wait_time : int
             Max time to wait (in seconds) to job completion.
         request_interval : int
@@ -98,7 +102,7 @@ class Cloudos:
         if request_interval > wait_time:
             request_interval = wait_time
         while elapsed < wait_time:
-            j_status = self.get_job_status(job_id, verify)
+            j_status = self.get_job_status(job_id, workspace_id, verify)
             j_status_content = json.loads(j_status.content)
             j_status_h = j_status_content["status"]
             j_name = j_status_content["name"]


### PR DESCRIPTION
# Overview

Adds workspace when running `job details/workdir/logs/results/abort/status` endpoint. This enables access details of other user's jobs in the workspace.

# JIRA

# TESTS

## `details`

## `workdir`

## `logs`

## `results`

## `abort`

## `status`