### PR TITLE
fix: update github actions to use a non-legacy node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Updates GitHub Actions workflow dependencies in line with lifebit-ai/api-server#5551.

- actions/checkout v4 to v6
- actions/setup-node v4 to v6
- Node.js 20 to 22 where configured in workflows
- tj-actions/changed-files v45 to v47 where present
- peter-evans/create-pull-request v7 to v8 where present